### PR TITLE
fix: add LIMIT clause to loadConnectingRelationships query

### DIFF
--- a/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
@@ -122,7 +122,7 @@ export class Neo4jExternalDatabase implements ExternalGraphDatabase {
     );
     return await this.executeQuery(
       credentials,
-      `MATCH (a)-[additionalRelationship]->(b) WHERE elementId(a) IN $existingNodeIds AND elementId(b) IN $existingNodeIds RETURN DISTINCT additionalRelationship;`,
+      `MATCH (a)-[additionalRelationship]->(b) WHERE elementId(a) IN $existingNodeIds AND elementId(b) IN $existingNodeIds RETURN DISTINCT additionalRelationship LIMIT ${ExternalGraphDatabaseQueryLimitConfig.maximalElements.toString()};`,
       {
         existingNodeIds: nodesIds,
       },


### PR DESCRIPTION
The query lacked a LIMIT, potentially returning excessive results in dense graphs. Added LIMIT 5000 to match the default limit config.