### PR TITLE
fix: change expandClusterNode params from string[] to SSet<string>

### DIFF
--- a/nakar-server/src/lib/external-database/ExternalGraphDatabase.ts
+++ b/nakar-server/src/lib/external-database/ExternalGraphDatabase.ts
@@ -51,8 +51,8 @@ export interface ExternalGraphDatabase {
 
   expandClusterNode(
     credentials: ExternalGraphDatabaseCredentials,
-    nodeIds: string[],
-    neighbors: string[],
+    nodeIds: SSet<string>,
+    neighbors: SSet<string>,
   ): Promise<ExternalGraphDatabaseQueryResult>;
 
   findRelationshipsByIds(

--- a/nakar-server/src/lib/external-database/ExternalGraphDatabaseService.ts
+++ b/nakar-server/src/lib/external-database/ExternalGraphDatabaseService.ts
@@ -174,8 +174,8 @@ export class ExternalGraphDatabaseService implements OnModuleDestroy {
 
   public async expandClusterNode(
     database: Result<'api::database-connection.database-connection'>,
-    nodeIds: string[],
-    neighbors: string[],
+    nodeIds: SSet<string>,
+    neighbors: SSet<string>,
   ): Promise<ExternalGraphDatabaseQueryResult> {
     const credentials: ExternalGraphDatabaseCredentials =
       this.parseCredentials(database);

--- a/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
@@ -354,15 +354,15 @@ ORDER BY lcount DESC, label ASC`,
 
   public async expandClusterNode(
     credentials: ExternalGraphDatabaseCredentials,
-    nodeIds: string[],
-    neighbors: string[],
+    nodeIds: SSet<string>,
+    neighbors: SSet<string>,
   ): Promise<ExternalGraphDatabaseQueryResult> {
     return await this.executeQuery(
       credentials,
       'MATCH (n) WHERE elementId(n) IN $nodeIds OPTIONAL MATCH (n)-[r]-(neighbor) WHERE elementId(neighbor) in $neighbors RETURN n, r',
       {
-        nodeIds: nodeIds,
-        neighbors: neighbors,
+        nodeIds: nodeIds.toArray(),
+        neighbors: neighbors.toArray(),
       },
       new ExternalGraphDatabaseQueryLimitConfig('default', 'graphElements'),
     );

--- a/nakar-server/src/lib/live-canvas/LiveCanvas.ts
+++ b/nakar-server/src/lib/live-canvas/LiveCanvas.ts
@@ -709,12 +709,9 @@ export class LiveCanvas {
             ? await this._externalGraphDatabase.expandClusterNode(
                 database,
                 node.compressed,
-                new SSet<string>(
-                  oldGraph
-                    .getNeighborsOfNode(node)
-                    .toArray()
-                    .map((n: GraphNode): string => n.nativeId),
-                ),
+                oldGraph
+                  .getNeighborsOfNode(node)
+                  .map((n: GraphNode): string => n.nativeId),
               )
             : await this._externalGraphDatabase.expandNode(
                 database,

--- a/nakar-server/src/lib/live-canvas/LiveCanvas.ts
+++ b/nakar-server/src/lib/live-canvas/LiveCanvas.ts
@@ -708,11 +708,13 @@ export class LiveCanvas {
           const expandResult: ExternalGraphDatabaseQueryResult = node.isCluster
             ? await this._externalGraphDatabase.expandClusterNode(
                 database,
-                node.compressed.toArray(),
-                oldGraph
-                  .getNeighborsOfNode(node)
-                  .toArray()
-                  .map((n: GraphNode): string => n.nativeId),
+                node.compressed,
+                new SSet<string>(
+                  oldGraph
+                    .getNeighborsOfNode(node)
+                    .toArray()
+                    .map((n: GraphNode): string => n.nativeId),
+                ),
               )
             : await this._externalGraphDatabase.expandNode(
                 database,


### PR DESCRIPTION
Aligns the interface, service, adapter, and caller to use SSet<string> consistently instead of string[] for nodeIds and neighbors parameters.