### PR TITLE
refactor: replace magic strings with LimitType and CollectionType

### DIFF
--- a/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
@@ -14,7 +14,7 @@ import type { ExternalGraphDatabaseCredentials } from '../../data/ExternalGraphD
 import type { ExternalGraphDatabaseQueryResult } from '../../data/ExternalGraphDatabaseQueryResult';
 import type { ExternalGraphDatabaseSearchCapabilities } from '../../data/ExternalGraphDatabaseSearchCapabilities';
 import type { ExternalGraphDatabaseNode } from '../../data/ExternalGraphDatabaseNode';
-import { ExternalGraphDatabaseQueryLimitConfig } from '../../data/ExternalGraphDatabaseQueryLimitConfig';
+import { ExternalGraphDatabaseQueryLimitConfig, LimitType, CollectionType } from '../../data/ExternalGraphDatabaseQueryLimitConfig';
 import { Neo4jGraphElementsFactory } from './Neo4jGraphElementsFactory';
 import { ExternalGraphDatabaseExpandNodePreviewEntry } from '../../data/ExternalGraphDatabaseExpandNodePreviewEntry';
 import { ExternalGraphDatabaseExpandNodePreview } from '../../data/ExternalGraphDatabaseExpandNodePreview';
@@ -126,7 +126,7 @@ export class Neo4jExternalDatabase implements ExternalGraphDatabase {
       {
         existingNodeIds: nodesIds,
       },
-      new ExternalGraphDatabaseQueryLimitConfig('default', 'graphElements'),
+      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
     );
   }
 
@@ -152,7 +152,7 @@ export class Neo4jExternalDatabase implements ExternalGraphDatabase {
           relationships: limit.relationships.toArray(),
           labels: limit.labels.toArray(),
         },
-        new ExternalGraphDatabaseQueryLimitConfig('default', 'graphElements'),
+        new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
       );
     } else {
       return await this.executeQuery(
@@ -161,7 +161,7 @@ export class Neo4jExternalDatabase implements ExternalGraphDatabase {
         {
           nodesIds: nodesIds,
         },
-        new ExternalGraphDatabaseQueryLimitConfig('preview', 'graphElements'),
+        new ExternalGraphDatabaseQueryLimitConfig(LimitType.preview, CollectionType.graphElements),
       );
     }
   }
@@ -181,7 +181,7 @@ ORDER BY rcount DESC, rtype ASC`,
         {
           nodesIds: nodesIds,
         },
-        new ExternalGraphDatabaseQueryLimitConfig('default', 'tableData'),
+        new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
       );
     const expandNodePreviewRelationshipEntries: ExternalGraphDatabaseExpandNodePreviewEntry[] =
       relationships.tableData.map(
@@ -204,7 +204,7 @@ ORDER BY lcount DESC, label ASC`,
       {
         nodesIds: nodesIds,
       },
-      new ExternalGraphDatabaseQueryLimitConfig('default', 'tableData'),
+      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
     );
     const expandNodePreviewLabelEntries: ExternalGraphDatabaseExpandNodePreviewEntry[] =
       labels.tableData.map(
@@ -236,7 +236,7 @@ ORDER BY lcount DESC, label ASC`,
       credentials,
       'SHOW INDEXES',
       {},
-      new ExternalGraphDatabaseQueryLimitConfig('default', 'tableData'),
+      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
     );
 
     const exactMatchNodeProperties: SMap<string, SSet<string>> = new SMap<
@@ -304,7 +304,7 @@ ORDER BY lcount DESC, label ASC`,
       searchTerm: searchTerm,
     };
     const limit: ExternalGraphDatabaseQueryLimitConfig =
-      new ExternalGraphDatabaseQueryLimitConfig('preview', 'graphElements');
+      new ExternalGraphDatabaseQueryLimitConfig(LimitType.preview, CollectionType.graphElements);
 
     queries.push(
       `MATCH (n) WHERE elementId(n) = $searchTerm\nRETURN n\nLIMIT ${limit.getLimit()}`,
@@ -348,7 +348,7 @@ ORDER BY lcount DESC, label ASC`,
       credentials,
       'MATCH (n) WHERE elementId(n) = $id RETURN n LIMIT 1;',
       { id: nativeNodeId },
-      new ExternalGraphDatabaseQueryLimitConfig('default', 'graphElements'),
+      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
     );
   }
 
@@ -364,7 +364,7 @@ ORDER BY lcount DESC, label ASC`,
         nodeIds: nodeIds,
         neighbors: neighbors,
       },
-      new ExternalGraphDatabaseQueryLimitConfig('default', 'graphElements'),
+      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
     );
   }
 
@@ -378,7 +378,7 @@ ORDER BY lcount DESC, label ASC`,
       {
         relationshipIds: relationshipIds,
       },
-      new ExternalGraphDatabaseQueryLimitConfig('default', 'graphElements'),
+      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
     );
   }
 
@@ -394,7 +394,7 @@ ORDER BY lcount DESC, label ASC`,
         elementIdA: elementIdA,
         elementIdB: elementIdB,
       },
-      new ExternalGraphDatabaseQueryLimitConfig('default', 'graphElements'),
+      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
     );
   }
 
@@ -427,7 +427,7 @@ ORDER BY lcount DESC, label ASC`,
         credentials,
         'CALL db.labels() YIELD label RETURN label ORDER BY label ASC',
         {},
-        new ExternalGraphDatabaseQueryLimitConfig('default', 'tableData'),
+        new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
       );
     const labels: SSet<string> = new SSet<string>(
       labelsResult.tableData.map((line: SMap<string, unknown>): string =>
@@ -445,7 +445,7 @@ ORDER BY lcount DESC, label ASC`,
         credentials,
         'CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType ORDER BY relationshipType ASC',
         {},
-        new ExternalGraphDatabaseQueryLimitConfig('default', 'tableData'),
+        new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
       );
     const relTypes: SSet<string> = new SSet<string>(
       relTypesResult.tableData.map((line: SMap<string, unknown>): string =>
@@ -498,7 +498,7 @@ ORDER BY lcount DESC, label ASC`,
       credentials,
       'MATCH (n) RETURN count(n) AS nodeCount',
       {},
-      new ExternalGraphDatabaseQueryLimitConfig('default', 'tableData'),
+      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
     );
     if (result.tableData.length === 0) {
       throw new Error('Unable to get node count from query.');
@@ -514,7 +514,7 @@ ORDER BY lcount DESC, label ASC`,
       credentials,
       'MATCH ()-[r]->() RETURN count(r) AS relationshipCount',
       {},
-      new ExternalGraphDatabaseQueryLimitConfig('default', 'tableData'),
+      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
     );
     if (result.tableData.length === 0) {
       throw new Error('Unable to get relationship count from query.');

--- a/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
@@ -14,7 +14,7 @@ import type { ExternalGraphDatabaseCredentials } from '../../data/ExternalGraphD
 import type { ExternalGraphDatabaseQueryResult } from '../../data/ExternalGraphDatabaseQueryResult';
 import type { ExternalGraphDatabaseSearchCapabilities } from '../../data/ExternalGraphDatabaseSearchCapabilities';
 import type { ExternalGraphDatabaseNode } from '../../data/ExternalGraphDatabaseNode';
-import { ExternalGraphDatabaseQueryLimitConfig, LimitType, CollectionType } from '../../data/ExternalGraphDatabaseQueryLimitConfig';
+import { ExternalGraphDatabaseQueryLimitConfig } from '../../data/ExternalGraphDatabaseQueryLimitConfig';
 import { Neo4jGraphElementsFactory } from './Neo4jGraphElementsFactory';
 import { ExternalGraphDatabaseExpandNodePreviewEntry } from '../../data/ExternalGraphDatabaseExpandNodePreviewEntry';
 import { ExternalGraphDatabaseExpandNodePreview } from '../../data/ExternalGraphDatabaseExpandNodePreview';
@@ -24,6 +24,8 @@ import { createChildLogger } from '../../../logger/createChildLogger';
 import type { ExternalGraphDatabaseStatsRelationship } from '../../data/ExternalGraphDatabaseStatsRelationship';
 import type { ExternalGraphDatabaseStatsLabel } from '../../data/ExternalGraphDatabaseStatsLabel';
 import { createHash, randomBytes } from 'crypto';
+import { ExternalGraphDatabaseQueryLimitConfigType } from '../../data/ExternalGraphDatabaseQueryLimitConfigType';
+import { ExternalGraphDatabaseQueryLimitConfigCollectionType } from '../../data/ExternalGraphDatabaseQueryLimitConfigCollectionType';
 
 export class Neo4jExternalDatabase implements ExternalGraphDatabase {
   private readonly _logger: Logger;
@@ -126,7 +128,10 @@ export class Neo4jExternalDatabase implements ExternalGraphDatabase {
       {
         existingNodeIds: nodesIds,
       },
-      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
+      new ExternalGraphDatabaseQueryLimitConfig(
+        ExternalGraphDatabaseQueryLimitConfigType.default,
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.graphElements,
+      ),
     );
   }
 
@@ -152,7 +157,10 @@ export class Neo4jExternalDatabase implements ExternalGraphDatabase {
           relationships: limit.relationships.toArray(),
           labels: limit.labels.toArray(),
         },
-        new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
+        new ExternalGraphDatabaseQueryLimitConfig(
+          ExternalGraphDatabaseQueryLimitConfigType.default,
+          ExternalGraphDatabaseQueryLimitConfigCollectionType.graphElements,
+        ),
       );
     } else {
       return await this.executeQuery(
@@ -161,7 +169,10 @@ export class Neo4jExternalDatabase implements ExternalGraphDatabase {
         {
           nodesIds: nodesIds,
         },
-        new ExternalGraphDatabaseQueryLimitConfig(LimitType.preview, CollectionType.graphElements),
+        new ExternalGraphDatabaseQueryLimitConfig(
+          ExternalGraphDatabaseQueryLimitConfigType.preview,
+          ExternalGraphDatabaseQueryLimitConfigCollectionType.graphElements,
+        ),
       );
     }
   }
@@ -181,7 +192,10 @@ ORDER BY rcount DESC, rtype ASC`,
         {
           nodesIds: nodesIds,
         },
-        new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
+        new ExternalGraphDatabaseQueryLimitConfig(
+          ExternalGraphDatabaseQueryLimitConfigType.default,
+          ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData,
+        ),
       );
     const expandNodePreviewRelationshipEntries: ExternalGraphDatabaseExpandNodePreviewEntry[] =
       relationships.tableData.map(
@@ -204,7 +218,10 @@ ORDER BY lcount DESC, label ASC`,
       {
         nodesIds: nodesIds,
       },
-      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
+      new ExternalGraphDatabaseQueryLimitConfig(
+        ExternalGraphDatabaseQueryLimitConfigType.default,
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData,
+      ),
     );
     const expandNodePreviewLabelEntries: ExternalGraphDatabaseExpandNodePreviewEntry[] =
       labels.tableData.map(
@@ -236,7 +253,10 @@ ORDER BY lcount DESC, label ASC`,
       credentials,
       'SHOW INDEXES',
       {},
-      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
+      new ExternalGraphDatabaseQueryLimitConfig(
+        ExternalGraphDatabaseQueryLimitConfigType.default,
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData,
+      ),
     );
 
     const exactMatchNodeProperties: SMap<string, SSet<string>> = new SMap<
@@ -304,7 +324,10 @@ ORDER BY lcount DESC, label ASC`,
       searchTerm: searchTerm,
     };
     const limit: ExternalGraphDatabaseQueryLimitConfig =
-      new ExternalGraphDatabaseQueryLimitConfig(LimitType.preview, CollectionType.graphElements);
+      new ExternalGraphDatabaseQueryLimitConfig(
+        ExternalGraphDatabaseQueryLimitConfigType.preview,
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.graphElements,
+      );
 
     queries.push(
       `MATCH (n) WHERE elementId(n) = $searchTerm\nRETURN n\nLIMIT ${limit.getLimit()}`,
@@ -348,7 +371,10 @@ ORDER BY lcount DESC, label ASC`,
       credentials,
       'MATCH (n) WHERE elementId(n) = $id RETURN n LIMIT 1;',
       { id: nativeNodeId },
-      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
+      new ExternalGraphDatabaseQueryLimitConfig(
+        ExternalGraphDatabaseQueryLimitConfigType.default,
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.graphElements,
+      ),
     );
   }
 
@@ -364,7 +390,10 @@ ORDER BY lcount DESC, label ASC`,
         nodeIds: nodeIds,
         neighbors: neighbors,
       },
-      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
+      new ExternalGraphDatabaseQueryLimitConfig(
+        ExternalGraphDatabaseQueryLimitConfigType.default,
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.graphElements,
+      ),
     );
   }
 
@@ -378,7 +407,10 @@ ORDER BY lcount DESC, label ASC`,
       {
         relationshipIds: relationshipIds,
       },
-      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
+      new ExternalGraphDatabaseQueryLimitConfig(
+        ExternalGraphDatabaseQueryLimitConfigType.default,
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.graphElements,
+      ),
     );
   }
 
@@ -394,7 +426,10 @@ ORDER BY lcount DESC, label ASC`,
         elementIdA: elementIdA,
         elementIdB: elementIdB,
       },
-      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.graphElements),
+      new ExternalGraphDatabaseQueryLimitConfig(
+        ExternalGraphDatabaseQueryLimitConfigType.default,
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.graphElements,
+      ),
     );
   }
 
@@ -427,7 +462,10 @@ ORDER BY lcount DESC, label ASC`,
         credentials,
         'CALL db.labels() YIELD label RETURN label ORDER BY label ASC',
         {},
-        new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
+        new ExternalGraphDatabaseQueryLimitConfig(
+          ExternalGraphDatabaseQueryLimitConfigType.default,
+          ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData,
+        ),
       );
     const labels: SSet<string> = new SSet<string>(
       labelsResult.tableData.map((line: SMap<string, unknown>): string =>
@@ -445,7 +483,10 @@ ORDER BY lcount DESC, label ASC`,
         credentials,
         'CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType ORDER BY relationshipType ASC',
         {},
-        new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
+        new ExternalGraphDatabaseQueryLimitConfig(
+          ExternalGraphDatabaseQueryLimitConfigType.default,
+          ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData,
+        ),
       );
     const relTypes: SSet<string> = new SSet<string>(
       relTypesResult.tableData.map((line: SMap<string, unknown>): string =>
@@ -498,7 +539,10 @@ ORDER BY lcount DESC, label ASC`,
       credentials,
       'MATCH (n) RETURN count(n) AS nodeCount',
       {},
-      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
+      new ExternalGraphDatabaseQueryLimitConfig(
+        ExternalGraphDatabaseQueryLimitConfigType.default,
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData,
+      ),
     );
     if (result.tableData.length === 0) {
       throw new Error('Unable to get node count from query.');
@@ -514,7 +558,10 @@ ORDER BY lcount DESC, label ASC`,
       credentials,
       'MATCH ()-[r]->() RETURN count(r) AS relationshipCount',
       {},
-      new ExternalGraphDatabaseQueryLimitConfig(LimitType.default, CollectionType.tableData),
+      new ExternalGraphDatabaseQueryLimitConfig(
+        ExternalGraphDatabaseQueryLimitConfigType.default,
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData,
+      ),
     );
     if (result.tableData.length === 0) {
       throw new Error('Unable to get relationship count from query.');

--- a/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseQueryLimitConfig.ts
+++ b/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseQueryLimitConfig.ts
@@ -1,23 +1,38 @@
 import { match } from 'ts-pattern';
 
+export const LimitType = {
+  preview: 'preview',
+  default: 'default',
+} as const;
+
+export type LimitType = (typeof LimitType)[keyof typeof LimitType];
+
+export const CollectionType = {
+  graphElements: 'graphElements',
+  tableData: 'tableData',
+  all: 'all',
+} as const;
+
+export type CollectionType = (typeof CollectionType)[keyof typeof CollectionType];
+
 export class ExternalGraphDatabaseQueryLimitConfig {
   public static readonly maximalElements: number = 5000;
   public static readonly maximalPreviewElements: number = 300;
 
   public constructor(
-    private readonly _type: 'preview' | 'default',
-    private readonly _collectionType: 'graphElements' | 'tableData' | 'all',
+    private readonly _type: LimitType,
+    private readonly _collectionType: CollectionType,
   ) {}
 
   public getLimit(): number {
     return match(this._type)
       .with(
-        'preview',
+        LimitType.preview,
         (): number =>
           ExternalGraphDatabaseQueryLimitConfig.maximalPreviewElements,
       )
       .with(
-        'default',
+        LimitType.default,
         (): number => ExternalGraphDatabaseQueryLimitConfig.maximalElements,
       )
       .exhaustive();
@@ -25,13 +40,15 @@ export class ExternalGraphDatabaseQueryLimitConfig {
 
   public shouldCollectGraphElements(): boolean {
     return (
-      this._collectionType === 'graphElements' || this._collectionType === 'all'
+      this._collectionType === CollectionType.graphElements ||
+      this._collectionType === CollectionType.all
     );
   }
 
   public shouldCollectTableData(): boolean {
     return (
-      this._collectionType === 'tableData' || this._collectionType === 'all'
+      this._collectionType === CollectionType.tableData ||
+      this._collectionType === CollectionType.all
     );
   }
 }

--- a/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseQueryLimitConfig.ts
+++ b/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseQueryLimitConfig.ts
@@ -1,38 +1,25 @@
 import { match } from 'ts-pattern';
-
-export const LimitType = {
-  preview: 'preview',
-  default: 'default',
-} as const;
-
-export type LimitType = (typeof LimitType)[keyof typeof LimitType];
-
-export const CollectionType = {
-  graphElements: 'graphElements',
-  tableData: 'tableData',
-  all: 'all',
-} as const;
-
-export type CollectionType = (typeof CollectionType)[keyof typeof CollectionType];
+import { ExternalGraphDatabaseQueryLimitConfigType } from './ExternalGraphDatabaseQueryLimitConfigType';
+import { ExternalGraphDatabaseQueryLimitConfigCollectionType } from './ExternalGraphDatabaseQueryLimitConfigCollectionType';
 
 export class ExternalGraphDatabaseQueryLimitConfig {
   public static readonly maximalElements: number = 5000;
   public static readonly maximalPreviewElements: number = 300;
 
   public constructor(
-    private readonly _type: LimitType,
-    private readonly _collectionType: CollectionType,
+    private readonly _type: ExternalGraphDatabaseQueryLimitConfigType,
+    private readonly _collectionType: ExternalGraphDatabaseQueryLimitConfigCollectionType,
   ) {}
 
   public getLimit(): number {
     return match(this._type)
       .with(
-        LimitType.preview,
+        ExternalGraphDatabaseQueryLimitConfigType.preview,
         (): number =>
           ExternalGraphDatabaseQueryLimitConfig.maximalPreviewElements,
       )
       .with(
-        LimitType.default,
+        ExternalGraphDatabaseQueryLimitConfigType.default,
         (): number => ExternalGraphDatabaseQueryLimitConfig.maximalElements,
       )
       .exhaustive();
@@ -40,15 +27,19 @@ export class ExternalGraphDatabaseQueryLimitConfig {
 
   public shouldCollectGraphElements(): boolean {
     return (
-      this._collectionType === CollectionType.graphElements ||
-      this._collectionType === CollectionType.all
+      this._collectionType ===
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.graphElements ||
+      this._collectionType ===
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.all
     );
   }
 
   public shouldCollectTableData(): boolean {
     return (
-      this._collectionType === CollectionType.tableData ||
-      this._collectionType === CollectionType.all
+      this._collectionType ===
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData ||
+      this._collectionType ===
+        ExternalGraphDatabaseQueryLimitConfigCollectionType.all
     );
   }
 }

--- a/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseQueryLimitConfigCollectionType.ts
+++ b/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseQueryLimitConfigCollectionType.ts
@@ -1,0 +1,5 @@
+export enum ExternalGraphDatabaseQueryLimitConfigCollectionType {
+  graphElements = 'graphElements',
+  tableData = 'tableData',
+  all = 'all',
+}

--- a/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseQueryLimitConfigType.ts
+++ b/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseQueryLimitConfigType.ts
@@ -1,0 +1,4 @@
+export enum ExternalGraphDatabaseQueryLimitConfigType {
+  preview = 'preview',
+  default = 'default',
+}

--- a/nakar-server/src/lib/live-canvas/LiveCanvas.ts
+++ b/nakar-server/src/lib/live-canvas/LiveCanvas.ts
@@ -23,7 +23,7 @@ import type { TaskQueueState } from '../../packages/task-queue/TaskQueueState';
 import { TaskQueueTask } from '../../packages/task-queue/TaskQueueTask';
 import type { ExternalGraphDatabaseRelationship } from '../external-database/data/ExternalGraphDatabaseRelationship';
 import type { ExternalGraphDatabaseQueryResult } from '../external-database/data/ExternalGraphDatabaseQueryResult';
-import { ExternalGraphDatabaseQueryLimitConfig } from '../external-database/data/ExternalGraphDatabaseQueryLimitConfig';
+import { ExternalGraphDatabaseQueryLimitConfig, LimitType, CollectionType } from '../external-database/data/ExternalGraphDatabaseQueryLimitConfig';
 import type { ExternalGraphDatabaseService } from '../external-database/ExternalGraphDatabaseService';
 import type { Result } from '@strapi/types/dist/modules/documents/result';
 import type { Logger } from '@strapi/logger';
@@ -402,8 +402,8 @@ export class LiveCanvas {
               query.query,
               argsForQuery,
               new ExternalGraphDatabaseQueryLimitConfig(
-                'default',
-                query.isTableQuery === true ? 'tableData' : 'graphElements',
+                LimitType.default,
+                query.isTableQuery === true ? CollectionType.tableData : CollectionType.graphElements,
               ),
             );
 
@@ -976,8 +976,8 @@ export class LiveCanvas {
             params.query,
             {},
             new ExternalGraphDatabaseQueryLimitConfig(
-              'default',
-              params.replace ? 'all' : 'graphElements',
+              LimitType.default,
+              params.replace ? CollectionType.all : CollectionType.graphElements,
             ),
           );
 

--- a/nakar-server/src/lib/live-canvas/LiveCanvas.ts
+++ b/nakar-server/src/lib/live-canvas/LiveCanvas.ts
@@ -23,7 +23,7 @@ import type { TaskQueueState } from '../../packages/task-queue/TaskQueueState';
 import { TaskQueueTask } from '../../packages/task-queue/TaskQueueTask';
 import type { ExternalGraphDatabaseRelationship } from '../external-database/data/ExternalGraphDatabaseRelationship';
 import type { ExternalGraphDatabaseQueryResult } from '../external-database/data/ExternalGraphDatabaseQueryResult';
-import { ExternalGraphDatabaseQueryLimitConfig, LimitType, CollectionType } from '../external-database/data/ExternalGraphDatabaseQueryLimitConfig';
+import { ExternalGraphDatabaseQueryLimitConfig } from '../external-database/data/ExternalGraphDatabaseQueryLimitConfig';
 import type { ExternalGraphDatabaseService } from '../external-database/ExternalGraphDatabaseService';
 import type { Result } from '@strapi/types/dist/modules/documents/result';
 import type { Logger } from '@strapi/logger';
@@ -63,6 +63,8 @@ import { CircleLayoutEngine } from '../../packages/physics/circle-layout-algorit
 import { NotFoundException } from '@nestjs/common';
 import { databaseBelongsToCanvas } from '../policies/databaseBelongsToCanvas';
 import { scenarioBelongsToCanvas } from '../policies/scenarioBelongsToCanvas';
+import { ExternalGraphDatabaseQueryLimitConfigType } from '../external-database/data/ExternalGraphDatabaseQueryLimitConfigType';
+import { ExternalGraphDatabaseQueryLimitConfigCollectionType } from '../external-database/data/ExternalGraphDatabaseQueryLimitConfigCollectionType';
 
 export class LiveCanvas {
   private readonly _logger: Logger = createChildLogger(this);
@@ -402,8 +404,10 @@ export class LiveCanvas {
               query.query,
               argsForQuery,
               new ExternalGraphDatabaseQueryLimitConfig(
-                LimitType.default,
-                query.isTableQuery === true ? CollectionType.tableData : CollectionType.graphElements,
+                ExternalGraphDatabaseQueryLimitConfigType.default,
+                query.isTableQuery === true
+                  ? ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData
+                  : ExternalGraphDatabaseQueryLimitConfigCollectionType.graphElements,
               ),
             );
 
@@ -976,8 +980,10 @@ export class LiveCanvas {
             params.query,
             {},
             new ExternalGraphDatabaseQueryLimitConfig(
-              LimitType.default,
-              params.replace ? CollectionType.all : CollectionType.graphElements,
+              ExternalGraphDatabaseQueryLimitConfigType.default,
+              params.replace
+                ? ExternalGraphDatabaseQueryLimitConfigCollectionType.all
+                : ExternalGraphDatabaseQueryLimitConfigCollectionType.graphElements,
             ),
           );
 


### PR DESCRIPTION
Introduced typed constants LimitType (preview/default) and CollectionType (graphElements/tableData/all) to replace raw string literals throughout the codebase.