### PR TITLE
perf: parallelize expandNodePreview queries with Promise.all

### DIFF
--- a/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
@@ -171,8 +171,11 @@ export class Neo4jExternalDatabase implements ExternalGraphDatabase {
     nodeIds: SSet<string>,
   ): Promise<ExternalGraphDatabaseExpandNodePreview> {
     const nodesIds: string[] = [...nodeIds.values()];
-    const relationships: ExternalGraphDatabaseQueryResult =
-      await this.executeQuery(
+    const [relationships, labels]: [
+      ExternalGraphDatabaseQueryResult,
+      ExternalGraphDatabaseQueryResult,
+    ] = await Promise.all([
+      this.executeQuery(
         credentials,
         `MATCH (a)-[neighbor]-(b)
 WHERE elementId(a) IN $nodesIds AND a <> b
@@ -182,7 +185,20 @@ ORDER BY rcount DESC, rtype ASC`,
           nodesIds: nodesIds,
         },
         new ExternalGraphDatabaseQueryLimitConfig('default', 'tableData'),
-      );
+      ),
+      this.executeQuery(
+        credentials,
+        `MATCH (a)-[]-(b)
+WHERE elementId(a) IN $nodesIds AND a <> b
+UNWIND labels(b) as label
+RETURN label, count(*) AS lcount
+ORDER BY lcount DESC, label ASC`,
+        {
+          nodesIds: nodesIds,
+        },
+        new ExternalGraphDatabaseQueryLimitConfig('default', 'tableData'),
+      ),
+    ]);
     const expandNodePreviewRelationshipEntries: ExternalGraphDatabaseExpandNodePreviewEntry[] =
       relationships.tableData.map(
         (
@@ -193,19 +209,6 @@ ORDER BY rcount DESC, rtype ASC`,
             Number(entry.get('rcount')),
           ),
       );
-
-    const labels: ExternalGraphDatabaseQueryResult = await this.executeQuery(
-      credentials,
-      `MATCH (a)-[]-(b)
-WHERE elementId(a) IN $nodesIds AND a <> b
-UNWIND labels(b) as label
-RETURN label, count(*) AS lcount
-ORDER BY lcount DESC, label ASC`,
-      {
-        nodesIds: nodesIds,
-      },
-      new ExternalGraphDatabaseQueryLimitConfig('default', 'tableData'),
-    );
     const expandNodePreviewLabelEntries: ExternalGraphDatabaseExpandNodePreviewEntry[] =
       labels.tableData.map(
         (

--- a/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
@@ -192,7 +192,10 @@ ORDER BY rcount DESC, rtype ASC`,
         {
           nodeIds: nodeIds.toArray(),
         },
-        new ExternalGraphDatabaseQueryLimitConfig(ExternalGraphDatabaseQueryLimitConfigType.default, ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData),
+        new ExternalGraphDatabaseQueryLimitConfig(
+          ExternalGraphDatabaseQueryLimitConfigType.default,
+          ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData,
+        ),
       ),
       this.executeQuery(
         credentials,
@@ -204,7 +207,10 @@ ORDER BY lcount DESC, label ASC`,
         {
           nodeIds: nodeIds.toArray(),
         },
-        new ExternalGraphDatabaseQueryLimitConfig(ExternalGraphDatabaseQueryLimitConfigType.default, ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData),
+        new ExternalGraphDatabaseQueryLimitConfig(
+          ExternalGraphDatabaseQueryLimitConfigType.default,
+          ExternalGraphDatabaseQueryLimitConfigCollectionType.tableData,
+        ),
       ),
     ]);
     const expandNodePreviewRelationshipEntries: ExternalGraphDatabaseExpandNodePreviewEntry[] =


### PR DESCRIPTION
The two independent queries (relationships and labels) are now executed concurrently instead of sequentially.