### PR TITLE
refactor: rename SSet.flatMap to toArrayBy

### DIFF
--- a/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
@@ -463,14 +463,14 @@ ORDER BY lcount DESC, label ASC`,
       await this._getRelationshipTypes(credentials);
     const stats: ExternalGraphDatabaseStats = {
       labelCount: labels.size,
-      labels: labels.flatMap(
+      labels: labels.toArrayBy(
         (label: string): ExternalGraphDatabaseStatsLabel => ({
           label: label,
           exploreQuery: this._exploreQueryOfLabel(label),
         }),
       ),
       relTypeCount: relTypes.size,
-      rels: relTypes.flatMap(
+      rels: relTypes.toArrayBy(
         (relType: string): ExternalGraphDatabaseStatsRelationship => ({
           relType: relType,
           exploreQuery: this._exploreQueryOfRelationshipType(relType),

--- a/nakar-server/src/lib/live-canvas/data/LiveCanvasUndoableData.ts
+++ b/nakar-server/src/lib/live-canvas/data/LiveCanvasUndoableData.ts
@@ -152,10 +152,10 @@ export class LiveCanvasUndoableData {
   public toPlain(): z.infer<typeof LiveCanvasUndoableData.schema> {
     return {
       id: this.id,
-      nodes: this.nodes.nodes.flatMap(
+      nodes: this.nodes.nodes.toArrayBy(
         (n: GraphNode): z.infer<typeof GraphNode.schema> => n.toPlain(),
       ),
-      edges: this.edges.edges.flatMap(
+      edges: this.edges.edges.toArrayBy(
         (e: GraphEdge): z.infer<typeof GraphEdge.schema> => e.toPlain(),
       ),
       metaData: this.metaData.toPlain(),

--- a/nakar-server/src/lib/schema/SchemaFactoryService.ts
+++ b/nakar-server/src/lib/schema/SchemaFactoryService.ts
@@ -305,11 +305,11 @@ export class SchemaFactoryService {
     const labelIndex: SMap<string, LabelDto> = this._createLabelIndex(canvas);
 
     const result: LiveCanvasGraphElementsDto = {
-      nodes: graph.nodes.nodes.flatMap(
+      nodes: graph.nodes.nodes.toArrayBy(
         (node: GraphNode): NodeDto =>
           this._createSchemaNode(node, canvas, degreeRange),
       ),
-      edges: graph.edges.edges.flatMap(
+      edges: graph.edges.edges.toArrayBy(
         (edge: GraphEdge): EdgeDto =>
           this._createSchemaEdge(
             edge,
@@ -688,7 +688,7 @@ export class SchemaFactoryService {
             displayName: note.author.username,
           })
         : null,
-      nodes: note.nodes.flatMap(
+      nodes: note.nodes.toArrayBy(
         (nodeReference: LiveCanvasNoteNodeReference): NodePreviewDto => {
           return new NodePreviewDto({
             id: nodeReference.id,

--- a/nakar-server/src/packages/set/Set.test.ts
+++ b/nakar-server/src/packages/set/Set.test.ts
@@ -99,10 +99,10 @@ void describe('SSet', (): void => {
     });
   });
 
-  void describe('flatMap', (): void => {
+  void describe('toArrayBy', (): void => {
     void it('returns mapped array', (): void => {
       const base: SSet<number> = new SSet<number>([1, 2, 3]);
-      const values: string[] = base.flatMap((value: number): string => {
+      const values: string[] = base.toArrayBy((value: number): string => {
         return `v-${value.toString()}`;
       });
       assert.deepEqual(values, ['v-1', 'v-2', 'v-3']);

--- a/nakar-server/src/packages/set/Set.ts
+++ b/nakar-server/src/packages/set/Set.ts
@@ -69,7 +69,7 @@ export class SSet<T> extends Set<T> {
     return n;
   }
 
-  public flatMap<V>(mapper: (value: T) => V): V[] {
+  public toArrayBy<V>(mapper: (value: T) => V): V[] {
     const n: V[] = [];
     for (const el of this) {
       n.push(mapper(el));


### PR DESCRIPTION
The method was misnamed - it returns V[] from T => V, not flattening nested arrays. Renamed to toArrayBy for clarity.