### PR TITLE
fix: make limitReached private in ExternalGraphDatabaseQueryResult

### DIFF
--- a/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseQueryResult.ts
+++ b/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseQueryResult.ts
@@ -10,8 +10,12 @@ export class ExternalGraphDatabaseQueryResult {
       ExternalGraphDatabaseRelationship
     >,
     public readonly tableData: SMap<string, unknown>[],
-    public limitReached: boolean,
+    private readonly _limitReached: boolean,
   ) {}
+
+  public get limitReached(): boolean {
+    return this._limitReached;
+  }
 
   public get size(): number {
     return this.nodes.size + this.relationships.size + this.tableData.length;


### PR DESCRIPTION
Changed limitReached from a public mutable field to a private readonly field exposed via a public getter, preventing external mutation and enforcing encapsulation.