### PR TITLE
feat(nakar-server): wikidata adapter

### DIFF
--- a/nakar-client-web/src-gen/api-client/types.gen.ts
+++ b/nakar-client-web/src-gen/api-client/types.gen.ts
@@ -39,7 +39,7 @@ export type DatabaseConnectionDto = {
     connectionUrl: string;
     database: string;
     nodeConfigurations: Array<NodeConfigurationDto>;
-    databaseType: 'neo4j' | 'sparql';
+    databaseType: 'neo4j' | 'sparql' | 'wikidata';
 };
 
 export type StartPageProjectDto = {
@@ -220,7 +220,7 @@ export type TestDatabaseConnectionRequestBodyDto = {
     password: string | null;
     database: string | null;
     connectionUrl: string;
-    databaseType: 'neo4j' | 'sparql';
+    databaseType: 'neo4j' | 'sparql' | 'wikidata';
 };
 
 export type TestDatabaseConnectionResponseBodyDto = {
@@ -245,7 +245,7 @@ export type UpdateDatabaseConnectionRequestBodyDto = {
     connectionUrl: string;
     browserUrl: string;
     credentialStoreConsent: boolean;
-    databaseType: 'neo4j' | 'sparql';
+    databaseType: 'neo4j' | 'sparql' | 'wikidata';
     nodeConfigurations: Array<UpdateNodeConfigurationRequestBodyDto>;
 };
 

--- a/nakar-client-web/src-gen/api-client/types.gen.ts
+++ b/nakar-client-web/src-gen/api-client/types.gen.ts
@@ -325,6 +325,7 @@ export type GetSearchCapabilitiesResponseBodyDto = {
 
 export type ExpandNodePreviewEntryDto = {
     identificator: string;
+    title: string;
     count: number;
 };
 

--- a/nakar-client-web/src/room/expand-node-preview-modal/SelectableTableData.tsx
+++ b/nakar-client-web/src/room/expand-node-preview-modal/SelectableTableData.tsx
@@ -1,4 +1,4 @@
-import { FormCheck, Stack } from "react-bootstrap";
+import { FormCheck, OverlayTrigger, Stack, Tooltip } from "react-bootstrap";
 import { DynamicList } from "../../shared/elements/DynamicList.tsx";
 import clsx from "clsx";
 import { numberFormat } from "../../shared/data/numberFormat.ts";
@@ -82,9 +82,19 @@ export function SelectableTableData(props: {
                   checked={props.selections.has(element.identificator)}
                   readOnly={true}
                 ></FormCheck>
-                <span className={"text-break flex-grow-1 flex-shrink-1"}>
-                  {element.identificator}
-                </span>
+                <OverlayTrigger
+                  placement={"left"}
+                  delay={{ show: 1000, hide: 0 }}
+                  overlay={<Tooltip>{element.identificator}</Tooltip>}
+                >
+                  <span
+                    className={
+                      "text-break flex-grow-1 flex-shrink-1 user-select-text text-wrap"
+                    }
+                  >
+                    {element.title}
+                  </span>
+                </OverlayTrigger>
                 <span
                   className={"pe-2 text-end flex-grow-0 flex-shrink-0 text-end"}
                 >

--- a/nakar-client-web/src/room/query-panel/QueryPanel.tsx
+++ b/nakar-client-web/src/room/query-panel/QueryPanel.tsx
@@ -167,14 +167,14 @@ export function QueryPanel() {
                       ])
                       .with("sparql", () => [
                         {
-                          title: "Triple abrufen",
+                          title: "Triples",
                           query:
                             "CONSTRUCT {?s ?p ?o .} WHERE {?s ?p ?o .} LIMIT 300",
                         },
                       ])
                       .with("wikidata", () => [
                         {
-                          title: "Könige des Heiligen Römischen Reiches",
+                          title: "Kings of the Holy Roman Empire",
                           query:
                             "CONSTRUCT { ?emperor <http://www.wikidata.org/prop/direct/P39> <http://www.wikidata.org/entity/Q181765> . } WHERE { ?emperor <http://www.wikidata.org/prop/direct/P39> <http://www.wikidata.org/entity/Q181765> . }",
                         },

--- a/nakar-client-web/src/room/query-panel/QueryPanel.tsx
+++ b/nakar-client-web/src/room/query-panel/QueryPanel.tsx
@@ -7,7 +7,7 @@ import { Collapsable } from "../../shared/elements/Collapsable.tsx";
 import { useEffect, useState } from "react";
 import { Loadable } from "../../shared/data/Loadable.ts";
 import { resultOrThrow } from "../../shared/data/resultOrThrow.ts";
-import { match } from "ts-pattern";
+import { match, P } from "ts-pattern";
 import { Label } from "../labels/Label.tsx";
 import { QueryPanelStatsDisplay } from "./QueryPanelStatsDisplay.tsx";
 import { DynamicList } from "../../shared/elements/DynamicList.tsx";
@@ -135,7 +135,7 @@ export function QueryPanel() {
                 placeholder={match(referencedDatabase.databaseType)
                   .with("neo4j", () => "MATCH (n) RETURN n;")
                   .with(
-                    "sparql",
+                    P.union("sparql", "wikidata"),
                     () => "CONSTRUCT {?s ?p ?o .} WHERE {?s ?p ?o .} LIMIT 300",
                   )
                   .exhaustive()}
@@ -167,9 +167,16 @@ export function QueryPanel() {
                       ])
                       .with("sparql", () => [
                         {
-                          title: "Example",
+                          title: "Triple abrufen",
                           query:
                             "CONSTRUCT {?s ?p ?o .} WHERE {?s ?p ?o .} LIMIT 300",
+                        },
+                      ])
+                      .with("wikidata", () => [
+                        {
+                          title: "Könige des Heiligen Römischen Reiches",
+                          query:
+                            "CONSTRUCT { ?emperor <http://www.wikidata.org/prop/direct/P39> <http://www.wikidata.org/entity/Q181765> . } WHERE { ?emperor <http://www.wikidata.org/prop/direct/P39> <http://www.wikidata.org/entity/Q181765> . }",
                         },
                       ])
                       .exhaustive()
@@ -180,9 +187,16 @@ export function QueryPanel() {
                             query.setQueryText(entry.query);
                           }}
                         >
-                          <Stack>
+                          <Stack
+                            style={{ maxWidth: "400px" }}
+                            className={"text-break"}
+                          >
                             <span className={"small"}>{entry.title}</span>
-                            <span className={"small text-muted font-monospace"}>
+                            <span
+                              className={
+                                "small text-muted font-monospace text-break text-wrap"
+                              }
+                            >
                               {entry.query}
                             </span>
                           </Stack>

--- a/nakar-client-web/src/shared/cms/DatabaseConnectionEditor.tsx
+++ b/nakar-client-web/src/shared/cms/DatabaseConnectionEditor.tsx
@@ -78,7 +78,7 @@ export function DatabaseConnectionEditor(props: {
               <Form.Group>
                 <Form.Label htmlFor={"database-type"}>Database Type</Form.Label>
                 <Form.Select
-                  style={{ width: "200px" }}
+                  style={{ width: "220px" }}
                   id={"database-type"}
                   value={props.value.databaseType}
                   onChange={(e) => {
@@ -93,6 +93,7 @@ export function DatabaseConnectionEditor(props: {
                     [
                       "neo4j",
                       "sparql",
+                      "wikidata",
                     ] satisfies UpdateDatabaseConnectionRequestBodyDto["databaseType"][]
                   ).map((databaseType) => (
                     <option value={databaseType} key={databaseType}>

--- a/nakar-client-web/src/shared/data/getDatabaseTypeDisplay.ts
+++ b/nakar-client-web/src/shared/data/getDatabaseTypeDisplay.ts
@@ -7,5 +7,6 @@ export function getDatabaseTypeDisplay(
   return match(input)
     .with("neo4j", () => "Neo4j")
     .with("sparql", () => "SPARQL")
+    .with("wikidata", () => "Wikidata over SPARQL")
     .exhaustive();
 }

--- a/nakar-server/src/api/database-connection/content-types/database-connection/schema.json
+++ b/nakar-server/src/api/database-connection/content-types/database-connection/schema.json
@@ -23,9 +23,13 @@
     },
     "databaseType": {
       "type": "enumeration",
-      "enum": ["neo4j", "sparql"],
+      "required": true,
       "default": "neo4j",
-      "required": true
+      "enum": [
+        "neo4j",
+        "sparql",
+        "wikidata"
+      ]
     },
     "username": {
       "type": "string"

--- a/nakar-server/src/lib/external-database/ExternalGraphDatabaseService.ts
+++ b/nakar-server/src/lib/external-database/ExternalGraphDatabaseService.ts
@@ -14,6 +14,7 @@ import type { ExternalGraphDatabase } from './ExternalGraphDatabase';
 import type { ExternalGraphDatabaseStats } from './data/ExternalGraphDatabaseStats';
 import { match, P } from 'ts-pattern';
 import { ExternalGraphDatabaseType } from './data/ExternalGraphDatabaseType';
+import { WikidataExternalDatabase } from './adapters/wikidata/WikidataExternalDatabase';
 
 @Injectable()
 export class ExternalGraphDatabaseService implements OnModuleDestroy {
@@ -35,6 +36,10 @@ export class ExternalGraphDatabaseService implements OnModuleDestroy {
       ExternalGraphDatabaseType.sparql,
       new SparqlExternalDatabase(),
     );
+    this._adapters.set(
+      ExternalGraphDatabaseType.wikidata,
+      new WikidataExternalDatabase(),
+    );
   }
 
   public parseCredentials(
@@ -50,6 +55,10 @@ export class ExternalGraphDatabaseService implements OnModuleDestroy {
         .with(
           'sparql',
           (): ExternalGraphDatabaseType => ExternalGraphDatabaseType.sparql,
+        )
+        .with(
+          'wikidata',
+          (): ExternalGraphDatabaseType => ExternalGraphDatabaseType.wikidata,
         )
         .with(
           P.nullish,

--- a/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/neo4j/Neo4jExternalDatabase.ts
@@ -218,20 +218,22 @@ ORDER BY lcount DESC, label ASC`,
         (
           entry: SMap<string, unknown>,
         ): ExternalGraphDatabaseExpandNodePreviewEntry =>
-          new ExternalGraphDatabaseExpandNodePreviewEntry(
-            String(entry.get('rtype')),
-            Number(entry.get('rcount')),
-          ),
+          new ExternalGraphDatabaseExpandNodePreviewEntry({
+            identificator: String(entry.get('rtype')),
+            title: String(entry.get('rtype')),
+            count: Number(entry.get('rcount')),
+          }),
       );
     const expandNodePreviewLabelEntries: ExternalGraphDatabaseExpandNodePreviewEntry[] =
       labels.tableData.map(
         (
           entry: SMap<string, unknown>,
         ): ExternalGraphDatabaseExpandNodePreviewEntry =>
-          new ExternalGraphDatabaseExpandNodePreviewEntry(
-            String(entry.get('label')),
-            Number(entry.get('lcount')),
-          ),
+          new ExternalGraphDatabaseExpandNodePreviewEntry({
+            identificator: String(entry.get('label')),
+            title: String(entry.get('label')),
+            count: Number(entry.get('lcount')),
+          }),
       );
 
     return new ExternalGraphDatabaseExpandNodePreview(

--- a/nakar-server/src/lib/external-database/adapters/sparql/SparqlExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/sparql/SparqlExternalDatabase.ts
@@ -19,7 +19,7 @@ import type { ExternalGraphDatabaseRelationship } from '../../data/ExternalGraph
 import { ExternalGraphDatabaseQueryLimitConfigType } from '../../data/ExternalGraphDatabaseQueryLimitConfigType';
 import { ExternalGraphDatabaseQueryLimitConfigCollectionType } from '../../data/ExternalGraphDatabaseQueryLimitConfigCollectionType';
 import type { ExternalGraphDatabaseStatsLabel } from '../../data/ExternalGraphDatabaseStatsLabel';
-import type { ExternalGraphDatabaseExpandNodePreviewEntry } from '../../data/ExternalGraphDatabaseExpandNodePreviewEntry';
+import { ExternalGraphDatabaseExpandNodePreviewEntry } from '../../data/ExternalGraphDatabaseExpandNodePreviewEntry';
 import type {
   Bindings,
   Literal,
@@ -27,6 +27,7 @@ import type {
   Quad_Object,
   Quad_Predicate,
   Quad_Subject,
+  Term,
 } from '@rdfjs/types';
 import toNT from '@rdfjs/to-ntriples';
 import { match } from 'ts-pattern';
@@ -171,9 +172,7 @@ WHERE {
         ),
       );
     } else {
-      const relationshipParts: string[] = limit.relationships
-        .toArray()
-        .map((rel: string): string => `<${rel}>`);
+      const relationshipParts: string[] = limit.relationships.toArray();
       const hasRelationshipFilter: boolean = relationshipParts.length > 0;
 
       const labelFilterFunctions: string[] = [];
@@ -251,7 +250,7 @@ WHERE {
 
     const [labelDataStream, relsResult]: [BindingsStream, BindingsStream] =
       await Promise.all([
-        this._runGenericSparqlQuery(
+        this.runGenericSparqlQuery(
           credentials,
           `
 SELECT
@@ -276,7 +275,7 @@ WHERE {
 }
     `,
         ),
-        this._runGenericSparqlQuery(
+        this.runGenericSparqlQuery(
           credentials,
           `
 SELECT ?p (COUNT(DISTINCT *) AS ?count)
@@ -310,32 +309,67 @@ ORDER BY DESC(?count)
       );
 
       if (namedNodeCount > 0) {
-        labelResult.push({
-          identificator: 'NamedNode' satisfies SparqlLabel,
-          count: namedNodeCount,
-        });
+        labelResult.push(
+          new ExternalGraphDatabaseExpandNodePreviewEntry({
+            identificator: 'NamedNode' satisfies SparqlLabel,
+            title: 'NamedNode' satisfies SparqlLabel,
+            count: namedNodeCount,
+          }),
+        );
       }
       if (blankNodeCount > 0) {
-        labelResult.push({
-          identificator: 'BlankNode' satisfies SparqlLabel,
-          count: blankNodeCount,
-        });
+        labelResult.push(
+          new ExternalGraphDatabaseExpandNodePreviewEntry({
+            identificator: 'BlankNode' satisfies SparqlLabel,
+            title: 'BlankNode' satisfies SparqlLabel,
+            count: blankNodeCount,
+          }),
+        );
       }
       if (literalCount > 0) {
-        labelResult.push({
-          identificator: 'Literal' satisfies SparqlLabel,
-          count: literalCount,
-        });
+        labelResult.push(
+          new ExternalGraphDatabaseExpandNodePreviewEntry({
+            identificator: 'Literal' satisfies SparqlLabel,
+            title: 'Literal' satisfies SparqlLabel,
+            count: literalCount,
+          }),
+        );
       }
     }
 
     const relationshipResults: ExternalGraphDatabaseExpandNodePreviewEntry[] =
       [];
     for await (const bindings of relsResult) {
-      relationshipResults.push({
-        identificator: bindings.get('p')?.value ?? '',
-        count: parseInt(bindings.get('count')?.value ?? '0'),
-      });
+      const term: Term | null = bindings.get('p') ?? null;
+      if (term == null) {
+        this._logger.error(
+          'Term in expand node preview not found. This should not happen.',
+        );
+        continue;
+      }
+      const sparqlRef: string = toNT(term);
+      const countTerm: Term | null = bindings.get('count') ?? null;
+      if (countTerm == null) {
+        this._logger.error(
+          'The count term in expand node preview not found. This should not happen.',
+        );
+        continue;
+      }
+      const count: number = parseInt(countTerm.value);
+      if (isNaN(count)) {
+        this._logger.error(
+          'The count term in expand node preview is not a number. This should not happen.',
+        );
+        continue;
+      }
+
+      relationshipResults.push(
+        new ExternalGraphDatabaseExpandNodePreviewEntry({
+          identificator: sparqlRef,
+          title: sparqlRef,
+          count: count,
+        }),
+      );
     }
 
     return new ExternalGraphDatabaseExpandNodePreview(
@@ -582,10 +616,34 @@ WHERE {
     await Promise.resolve();
   }
 
+  public async runGenericSparqlQuery(
+    credentials: ExternalGraphDatabaseCredentials,
+    query: string,
+  ): Promise<BindingsStream> {
+    const queryId: string = v4();
+    const url: URL = this._assertConnectionUrl(credentials);
+    this._logger.debug(
+      `Will start SPARQL Query to ${url.toString()} (${queryId}): ${query}`,
+    );
+
+    const myEngine: QueryEngine = this._queryEngine;
+    const bindingsStream: BindingsStream = await myEngine.queryBindings(query, {
+      sources: [url.toString()],
+    });
+
+    this._logger.debug(`Did start streaming query response of ${queryId}`);
+
+    bindingsStream.on('end', (): void => {
+      this._logger.debug(`Query ${queryId} finished`);
+    });
+
+    return bindingsStream;
+  }
+
   private async _loadRelationshipTypes(
     credentials: ExternalGraphDatabaseCredentials,
   ): Promise<ExternalGraphDatabaseStatsRelationship[]> {
-    const result: BindingsStream = await this._runGenericSparqlQuery(
+    const result: BindingsStream = await this.runGenericSparqlQuery(
       credentials,
       `SELECT DISTINCT ?p
 WHERE {
@@ -621,7 +679,7 @@ LIMIT ${ExternalGraphDatabaseQueryLimitConfig.maximalPreviewElements}`,
   private async _loadRelationshipsCount(
     credentials: ExternalGraphDatabaseCredentials,
   ): Promise<number> {
-    const result: BindingsStream = await this._runGenericSparqlQuery(
+    const result: BindingsStream = await this.runGenericSparqlQuery(
       credentials,
       `
 SELECT (COUNT(*) AS ?count)
@@ -655,30 +713,6 @@ WHERE {
     }
 
     return numberValue;
-  }
-
-  private async _runGenericSparqlQuery(
-    credentials: ExternalGraphDatabaseCredentials,
-    query: string,
-  ): Promise<BindingsStream> {
-    const queryId: string = v4();
-    const url: URL = this._assertConnectionUrl(credentials);
-    this._logger.debug(
-      `Will start SPARQL Query to ${url.toString()} (${queryId}): ${query}`,
-    );
-
-    const myEngine: QueryEngine = this._queryEngine;
-    const bindingsStream: BindingsStream = await myEngine.queryBindings(query, {
-      sources: [url.toString()],
-    });
-
-    this._logger.debug(`Did start streaming query response of ${queryId}`);
-
-    bindingsStream.on('end', (): void => {
-      this._logger.debug(`Query ${queryId} finished`);
-    });
-
-    return bindingsStream;
   }
 
   private _assertConnectionUrl(

--- a/nakar-server/src/lib/external-database/adapters/sparql/SparqlExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/sparql/SparqlExternalDatabase.ts
@@ -343,7 +343,7 @@ ORDER BY DESC(?count)
       const term: Term | null = bindings.get('p') ?? null;
       if (term == null) {
         this._logger.error(
-          'Term in expand node preview not found. This should not happen.',
+          'Term in expand node preview was not found. This should not happen.',
         );
         continue;
       }
@@ -351,7 +351,7 @@ ORDER BY DESC(?count)
       const countTerm: Term | null = bindings.get('count') ?? null;
       if (countTerm == null) {
         this._logger.error(
-          'The count term in expand node preview not found. This should not happen.',
+          'The count term in expand node preview was not found. This should not happen.',
         );
         continue;
       }

--- a/nakar-server/src/lib/external-database/adapters/wikidata/WikidataExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/wikidata/WikidataExternalDatabase.ts
@@ -1,0 +1,120 @@
+import type { SSet } from '../../../../packages/set/Set';
+import type { ExternalGraphDatabase } from '../../ExternalGraphDatabase';
+import type { ExternalGraphDatabaseCredentials } from '../../data/ExternalGraphDatabaseCredentials';
+import type { ExternalGraphDatabaseExpandNodePreview } from '../../data/ExternalGraphDatabaseExpandNodePreview';
+import type { ExternalGraphDatabaseQueryLimitConfig } from '../../data/ExternalGraphDatabaseQueryLimitConfig';
+import type { ExternalGraphDatabaseQueryResult } from '../../data/ExternalGraphDatabaseQueryResult';
+import type { ExternalGraphDatabaseSearchCapabilities } from '../../data/ExternalGraphDatabaseSearchCapabilities';
+import type { ExternalGraphDatabaseStats } from '../../data/ExternalGraphDatabaseStats';
+import { SparqlExternalDatabase } from '../sparql/SparqlExternalDatabase';
+import type { ExternalGraphDatabaseNode } from '../../data/ExternalGraphDatabaseNode';
+
+export class WikidataExternalDatabase implements ExternalGraphDatabase {
+  private readonly _sparqlAdapter: SparqlExternalDatabase;
+
+  public constructor() {
+    this._sparqlAdapter = new SparqlExternalDatabase();
+  }
+
+  public async executeQuery(
+    credentials: ExternalGraphDatabaseCredentials,
+    query: string,
+    queryArguments: Record<string, unknown>,
+    limitConfig: ExternalGraphDatabaseQueryLimitConfig,
+  ): Promise<ExternalGraphDatabaseQueryResult> {
+    return await this._sparqlAdapter.executeQuery(
+      credentials,
+      query,
+      queryArguments,
+      limitConfig,
+    );
+  }
+
+  public async loadConnectingRelationships(
+    credentials: ExternalGraphDatabaseCredentials,
+    nodeIds: SSet<string>,
+  ): Promise<ExternalGraphDatabaseQueryResult> {
+    return await this._sparqlAdapter.loadConnectingRelationships(
+      credentials,
+      nodeIds,
+    );
+  }
+
+  public async expandNode(
+    credentials: ExternalGraphDatabaseCredentials,
+    nodeIds: SSet<string>,
+    limit: {
+      relationships: SSet<string>;
+      labels: SSet<string>;
+    } | null,
+  ): Promise<ExternalGraphDatabaseQueryResult> {
+    return await this._sparqlAdapter.expandNode(credentials, nodeIds, limit);
+  }
+
+  public async expandNodePreview(
+    credentials: ExternalGraphDatabaseCredentials,
+    nodeIds: SSet<string>,
+  ): Promise<ExternalGraphDatabaseExpandNodePreview> {
+    return await this._sparqlAdapter.expandNodePreview(credentials, nodeIds);
+  }
+
+  public async getStats(
+    credentials: ExternalGraphDatabaseCredentials,
+  ): Promise<ExternalGraphDatabaseStats> {
+    return await this._sparqlAdapter.getStats(credentials);
+  }
+
+  public async getSearchCapabilities(): Promise<ExternalGraphDatabaseSearchCapabilities> {
+    return await this._sparqlAdapter.getSearchCapabilities();
+  }
+
+  public async search(
+    credentials: ExternalGraphDatabaseCredentials,
+    searchTerm: string,
+  ): Promise<ExternalGraphDatabaseNode[]> {
+    return await this._sparqlAdapter.search(credentials, searchTerm);
+  }
+
+  public async findNodeByNativeId(
+    credentials: ExternalGraphDatabaseCredentials,
+    nativeNodeId: string,
+  ): Promise<ExternalGraphDatabaseQueryResult> {
+    return await this._sparqlAdapter.findNodeByNativeId(
+      credentials,
+      nativeNodeId,
+    );
+  }
+
+  public async expandClusterNode(
+    credentials: ExternalGraphDatabaseCredentials,
+    nodeIds: SSet<string>,
+    neighbors: SSet<string>,
+  ): Promise<ExternalGraphDatabaseQueryResult> {
+    return await this._sparqlAdapter.expandClusterNode(
+      credentials,
+      nodeIds,
+      neighbors,
+    );
+  }
+
+  public async findRelationshipsByIds(
+    credentials: ExternalGraphDatabaseCredentials,
+    relationshipIds: string[],
+  ): Promise<ExternalGraphDatabaseQueryResult> {
+    return await this._sparqlAdapter.findRelationshipsByIds(
+      credentials,
+      relationshipIds,
+    );
+  }
+
+  public async findShortestPath(
+    credentials: ExternalGraphDatabaseCredentials,
+    nodeIds: SSet<string>,
+  ): Promise<ExternalGraphDatabaseQueryResult> {
+    return await this._sparqlAdapter.findShortestPath(credentials, nodeIds);
+  }
+
+  public async shutdown(): Promise<void> {
+    await this._sparqlAdapter.shutdown();
+  }
+}

--- a/nakar-server/src/lib/external-database/adapters/wikidata/WikidataExternalDatabase.ts
+++ b/nakar-server/src/lib/external-database/adapters/wikidata/WikidataExternalDatabase.ts
@@ -1,4 +1,4 @@
-import type { SSet } from '../../../../packages/set/Set';
+import { SSet } from '../../../../packages/set/Set';
 import type { ExternalGraphDatabase } from '../../ExternalGraphDatabase';
 import type { ExternalGraphDatabaseCredentials } from '../../data/ExternalGraphDatabaseCredentials';
 import type { ExternalGraphDatabaseExpandNodePreview } from '../../data/ExternalGraphDatabaseExpandNodePreview';
@@ -8,6 +8,12 @@ import type { ExternalGraphDatabaseSearchCapabilities } from '../../data/Externa
 import type { ExternalGraphDatabaseStats } from '../../data/ExternalGraphDatabaseStats';
 import { SparqlExternalDatabase } from '../sparql/SparqlExternalDatabase';
 import type { ExternalGraphDatabaseNode } from '../../data/ExternalGraphDatabaseNode';
+import { SMap } from '../../../../packages/map/Map';
+import type { ExternalGraphDatabaseExpandNodePreviewEntry } from '../../data/ExternalGraphDatabaseExpandNodePreviewEntry';
+import type { BindingsStream } from '@comunica/types';
+import type { Term } from '@rdfjs/types';
+import toNT from '@rdfjs/to-ntriples';
+import type { ExternalGraphDatabaseRelationship } from '../../data/ExternalGraphDatabaseRelationship';
 
 export class WikidataExternalDatabase implements ExternalGraphDatabase {
   private readonly _sparqlAdapter: SparqlExternalDatabase;
@@ -22,22 +28,28 @@ export class WikidataExternalDatabase implements ExternalGraphDatabase {
     queryArguments: Record<string, unknown>,
     limitConfig: ExternalGraphDatabaseQueryLimitConfig,
   ): Promise<ExternalGraphDatabaseQueryResult> {
-    return await this._sparqlAdapter.executeQuery(
-      credentials,
-      query,
-      queryArguments,
-      limitConfig,
-    );
+    const result: ExternalGraphDatabaseQueryResult =
+      await this._sparqlAdapter.executeQuery(
+        credentials,
+        query,
+        queryArguments,
+        limitConfig,
+      );
+    await this._applyTitleToQueryResult(result, credentials);
+    return result;
   }
 
   public async loadConnectingRelationships(
     credentials: ExternalGraphDatabaseCredentials,
     nodeIds: SSet<string>,
   ): Promise<ExternalGraphDatabaseQueryResult> {
-    return await this._sparqlAdapter.loadConnectingRelationships(
-      credentials,
-      nodeIds,
-    );
+    const result: ExternalGraphDatabaseQueryResult =
+      await this._sparqlAdapter.loadConnectingRelationships(
+        credentials,
+        nodeIds,
+      );
+    await this._applyTitleToQueryResult(result, credentials);
+    return result;
   }
 
   public async expandNode(
@@ -48,14 +60,37 @@ export class WikidataExternalDatabase implements ExternalGraphDatabase {
       labels: SSet<string>;
     } | null,
   ): Promise<ExternalGraphDatabaseQueryResult> {
-    return await this._sparqlAdapter.expandNode(credentials, nodeIds, limit);
+    const result: ExternalGraphDatabaseQueryResult =
+      await this._sparqlAdapter.expandNode(credentials, nodeIds, limit);
+    await this._applyTitleToQueryResult(result, credentials);
+    return result;
   }
 
   public async expandNodePreview(
     credentials: ExternalGraphDatabaseCredentials,
     nodeIds: SSet<string>,
   ): Promise<ExternalGraphDatabaseExpandNodePreview> {
-    return await this._sparqlAdapter.expandNodePreview(credentials, nodeIds);
+    const result: ExternalGraphDatabaseExpandNodePreview =
+      await this._sparqlAdapter.expandNodePreview(credentials, nodeIds);
+    const nodeUrisToResolveTitle: SSet<string> = new SSet<string>(
+      result.relationships.map(
+        (r: ExternalGraphDatabaseExpandNodePreviewEntry): string =>
+          r.identificator,
+      ),
+    );
+    const resolvedTitles: SMap<string, string> = await this._resolveNodeTitles(
+      nodeUrisToResolveTitle,
+      credentials,
+    );
+    for (const entry of result.relationships) {
+      const title: string | null =
+        resolvedTitles.get(entry.identificator) ?? null;
+      if (title != null) {
+        entry.title = title;
+      }
+    }
+
+    return result;
   }
 
   public async getStats(
@@ -72,17 +107,22 @@ export class WikidataExternalDatabase implements ExternalGraphDatabase {
     credentials: ExternalGraphDatabaseCredentials,
     searchTerm: string,
   ): Promise<ExternalGraphDatabaseNode[]> {
-    return await this._sparqlAdapter.search(credentials, searchTerm);
+    const result: ExternalGraphDatabaseNode[] =
+      await this._sparqlAdapter.search(credentials, searchTerm);
+
+    await this._applyNodeTitlesToNodeArray(result, credentials);
+
+    return result;
   }
 
   public async findNodeByNativeId(
     credentials: ExternalGraphDatabaseCredentials,
     nativeNodeId: string,
   ): Promise<ExternalGraphDatabaseQueryResult> {
-    return await this._sparqlAdapter.findNodeByNativeId(
-      credentials,
-      nativeNodeId,
-    );
+    const result: ExternalGraphDatabaseQueryResult =
+      await this._sparqlAdapter.findNodeByNativeId(credentials, nativeNodeId);
+    await this._applyTitleToQueryResult(result, credentials);
+    return result;
   }
 
   public async expandClusterNode(
@@ -90,31 +130,176 @@ export class WikidataExternalDatabase implements ExternalGraphDatabase {
     nodeIds: SSet<string>,
     neighbors: SSet<string>,
   ): Promise<ExternalGraphDatabaseQueryResult> {
-    return await this._sparqlAdapter.expandClusterNode(
-      credentials,
-      nodeIds,
-      neighbors,
-    );
+    const result: ExternalGraphDatabaseQueryResult =
+      await this._sparqlAdapter.expandClusterNode(
+        credentials,
+        nodeIds,
+        neighbors,
+      );
+    await this._applyTitleToQueryResult(result, credentials);
+    return result;
   }
 
   public async findRelationshipsByIds(
     credentials: ExternalGraphDatabaseCredentials,
     relationshipIds: string[],
   ): Promise<ExternalGraphDatabaseQueryResult> {
-    return await this._sparqlAdapter.findRelationshipsByIds(
-      credentials,
-      relationshipIds,
-    );
+    const result: ExternalGraphDatabaseQueryResult =
+      await this._sparqlAdapter.findRelationshipsByIds(
+        credentials,
+        relationshipIds,
+      );
+    await this._applyTitleToQueryResult(result, credentials);
+    return result;
   }
 
   public async findShortestPath(
     credentials: ExternalGraphDatabaseCredentials,
     nodeIds: SSet<string>,
   ): Promise<ExternalGraphDatabaseQueryResult> {
-    return await this._sparqlAdapter.findShortestPath(credentials, nodeIds);
+    const result: ExternalGraphDatabaseQueryResult =
+      await this._sparqlAdapter.findShortestPath(credentials, nodeIds);
+    await this._applyTitleToQueryResult(result, credentials);
+    return result;
   }
 
   public async shutdown(): Promise<void> {
     await this._sparqlAdapter.shutdown();
+  }
+
+  private async _resolveNodeTitles(
+    nodeUris: SSet<string>,
+    credentials: ExternalGraphDatabaseCredentials,
+  ): Promise<SMap<string, string>> {
+    if (nodeUris.size === 0) {
+      return new SMap();
+    }
+    const bindingsStream: BindingsStream =
+      await this._sparqlAdapter.runGenericSparqlQuery(
+        credentials,
+        `
+SELECT ?input ?inputLabel
+WHERE {
+  VALUES ?input { ${nodeUris.toArray().join(' ')} }
+  
+  {
+    ?input <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+    BIND(?label AS ?inputLabel)
+  }
+  UNION {
+    ?intermediateEntity <http://wikiba.se/ontology#claim> ?input .
+    ?intermediateEntity <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+    BIND(CONCAT(?label, " (Claim)") AS ?inputLabel)
+  }
+  UNION {
+    ?intermediateEntity <http://wikiba.se/ontology#directClaim> ?input .
+    ?intermediateEntity <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+    BIND(CONCAT(?label, "") AS ?inputLabel)
+  }
+  UNION {
+    ?intermediateEntity <http://wikiba.se/ontology#directClaimNormalized> ?input .
+    ?intermediateEntity <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+    BIND(CONCAT(?label, " (Normalized)") AS ?inputLabel)
+  }
+  UNION {
+    ?intermediateEntity <http://wikiba.se/ontology#statementProperty> ?input .
+    ?intermediateEntity <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+    BIND(CONCAT(?label, " (Statement Property)") AS ?inputLabel)
+  }
+  UNION {
+    ?intermediateEntity <http://wikiba.se/ontology#statementValueNormalized> ?input .
+    ?intermediateEntity <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+    BIND(CONCAT(?label, " (Statement Value Normalized)") AS ?inputLabel)
+  }
+  UNION {
+    ?intermediateEntity <http://wikiba.se/ontology#reference> ?input .
+    ?intermediateEntity <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+    BIND(CONCAT(?label, " (Reference)") AS ?inputLabel)
+  }
+  
+  FILTER(LANG(?label) IN ("de", "mul"))
+}
+    `,
+      );
+
+    const result: SMap<string, string> = new SMap<string, string>();
+
+    for await (const entry of bindingsStream) {
+      const uriTerm: Term | null = entry.get('input') ?? null;
+      const uri: string | null = uriTerm == null ? null : toNT(uriTerm);
+      const title: string | null = entry.get('inputLabel')?.value ?? null;
+      if (uri != null && title != null) {
+        result.set(uri, title);
+      }
+    }
+
+    return result;
+  }
+
+  private async _applyTitleToQueryResult(
+    result: ExternalGraphDatabaseQueryResult,
+    credentials: ExternalGraphDatabaseCredentials,
+  ): Promise<void> {
+    await Promise.all([
+      this._applyNodeTitlesToNodeArray(
+        result.nodes.toValueArray(),
+        credentials,
+      ),
+      this._applyNodeTitlesToRelationshipArray(
+        result.relationships.toValueArray(),
+        credentials,
+      ),
+    ]);
+  }
+
+  private async _applyNodeTitlesToNodeArray(
+    nodes: ExternalGraphDatabaseNode[],
+    credentials: ExternalGraphDatabaseCredentials,
+  ): Promise<void> {
+    const resolvedNodeTitles: SMap<string, string> =
+      await this._resolveNodeTitles(
+        new SSet(
+          nodes.map(
+            (n: ExternalGraphDatabaseNode): string =>
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+              n.properties['sparql'] as string,
+          ),
+        ),
+        credentials,
+      );
+    for (const entry of nodes) {
+      const title: string | null =
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        resolvedNodeTitles.get(entry.properties['sparql'] as string) ?? null;
+      if (title != null) {
+        entry.properties['label'] = title;
+      }
+    }
+  }
+
+  private async _applyNodeTitlesToRelationshipArray(
+    relationships: ExternalGraphDatabaseRelationship[],
+    credentials: ExternalGraphDatabaseCredentials,
+  ): Promise<void> {
+    const resolvedRelationshipTitles: SMap<string, string> =
+      await this._resolveNodeTitles(
+        new SSet(
+          relationships.map(
+            (n: ExternalGraphDatabaseRelationship): string =>
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+              n.properties['sparql'] as string,
+          ),
+        ),
+        credentials,
+      );
+    for (const entry of relationships) {
+      const title: string | null =
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        resolvedRelationshipTitles.get(entry.properties['sparql'] as string) ??
+        null;
+      if (title != null) {
+        entry.type = title;
+      }
+    }
   }
 }

--- a/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseExpandNodePreviewEntry.ts
+++ b/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseExpandNodePreviewEntry.ts
@@ -1,6 +1,15 @@
 export class ExternalGraphDatabaseExpandNodePreviewEntry {
-  public constructor(
-    public readonly identificator: string,
-    public readonly count: number,
-  ) {}
+  public identificator: string;
+  public title: string;
+  public count: number;
+
+  public constructor(data: {
+    identificator: string;
+    title: string;
+    count: number;
+  }) {
+    this.identificator = data.identificator;
+    this.title = data.title;
+    this.count = data.count;
+  }
 }

--- a/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseRelationship.ts
+++ b/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseRelationship.ts
@@ -2,11 +2,11 @@ import type { SSet } from '../../../packages/set/Set';
 import type { ExternalGraphDatabaseCredentials } from './ExternalGraphDatabaseCredentials';
 
 export interface ExternalGraphDatabaseRelationship {
-  readonly nativeId: string;
-  readonly type: string;
-  readonly startNodeId: string;
-  readonly endNodeId: string;
-  readonly properties: Record<string, unknown>;
-  readonly keys: SSet<string>;
-  readonly source: ExternalGraphDatabaseCredentials;
+  nativeId: string;
+  type: string;
+  startNodeId: string;
+  endNodeId: string;
+  properties: Record<string, unknown>;
+  keys: SSet<string>;
+  source: ExternalGraphDatabaseCredentials;
 }

--- a/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseType.ts
+++ b/nakar-server/src/lib/external-database/data/ExternalGraphDatabaseType.ts
@@ -1,4 +1,5 @@
 export enum ExternalGraphDatabaseType {
   neo4j = 'neo4j',
   sparql = 'sparql',
+  wikidata = 'wikidata',
 }

--- a/nakar-server/src/lib/http/routes/canvas-database-connection/CanvasDatabaseConnectionController.ts
+++ b/nakar-server/src/lib/http/routes/canvas-database-connection/CanvasDatabaseConnectionController.ts
@@ -243,6 +243,7 @@ export class CanvasDatabaseConnectionController {
         ): ExpandNodePreviewEntryDto =>
           new ExpandNodePreviewEntryDto({
             identificator: l.identificator,
+            title: l.title,
             count: l.count,
           }),
       ),
@@ -252,6 +253,7 @@ export class CanvasDatabaseConnectionController {
         ): ExpandNodePreviewEntryDto =>
           new ExpandNodePreviewEntryDto({
             identificator: l.identificator,
+            title: l.title,
             count: l.count,
           }),
       ),

--- a/nakar-server/src/lib/http/routes/canvas-database-connection/dto/ExpandNodePreviewEntryDto.ts
+++ b/nakar-server/src/lib/http/routes/canvas-database-connection/dto/ExpandNodePreviewEntryDto.ts
@@ -4,11 +4,19 @@ export class ExpandNodePreviewEntryDto {
   @ApiProperty({ type: String })
   public identificator: string;
 
+  @ApiProperty({ type: String })
+  public title: string;
+
   @ApiProperty({ type: Number })
   public count: number;
 
-  public constructor(data: { identificator: string; count: number }) {
+  public constructor(data: {
+    identificator: string;
+    title: string;
+    count: number;
+  }) {
     this.identificator = data.identificator;
+    this.title = data.title;
     this.count = data.count;
   }
 }

--- a/nakar-server/src/lib/http/routes/database-connection/DatabaseConnectionController.ts
+++ b/nakar-server/src/lib/http/routes/database-connection/DatabaseConnectionController.ts
@@ -99,6 +99,11 @@ export class DatabaseConnectionController {
               DatabaseConnectionDatabaseType.sparql,
               (): ExternalGraphDatabaseType => ExternalGraphDatabaseType.sparql,
             )
+            .with(
+              DatabaseConnectionDatabaseType.wikidata,
+              (): ExternalGraphDatabaseType =>
+                ExternalGraphDatabaseType.wikidata,
+            )
             .exhaustive(),
         });
 

--- a/nakar-server/src/lib/http/routes/database-connection/dto/DatabaseConnectionDatabaseType.ts
+++ b/nakar-server/src/lib/http/routes/database-connection/dto/DatabaseConnectionDatabaseType.ts
@@ -1,4 +1,5 @@
 export enum DatabaseConnectionDatabaseType {
   neo4j = 'neo4j',
   sparql = 'sparql',
+  wikidata = 'wikidata',
 }

--- a/nakar-server/src/lib/schema/SchemaFactoryService.ts
+++ b/nakar-server/src/lib/schema/SchemaFactoryService.ts
@@ -121,6 +121,11 @@ export class SchemaFactoryService {
             DatabaseConnectionDatabaseType.sparql,
         )
         .with(
+          'wikidata',
+          (): DatabaseConnectionDatabaseType =>
+            DatabaseConnectionDatabaseType.wikidata,
+        )
+        .with(
           P.nullish,
           (): DatabaseConnectionDatabaseType =>
             DatabaseConnectionDatabaseType.neo4j,

--- a/nakar-server/types/generated/contentTypes.d.ts
+++ b/nakar-server/types/generated/contentTypes.d.ts
@@ -539,7 +539,9 @@ export interface ApiDatabaseConnectionDatabaseConnection
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
     database: Schema.Attribute.String;
-    databaseType: Schema.Attribute.Enumeration<['neo4j', 'sparql']> &
+    databaseType: Schema.Attribute.Enumeration<
+      ['neo4j', 'sparql', 'wikidata']
+    > &
       Schema.Attribute.Required &
       Schema.Attribute.DefaultTo<'neo4j'>;
     locale: Schema.Attribute.String & Schema.Attribute.Private;


### PR DESCRIPTION
Todo:

- [ ] Unsafe as string cast (WikidataExternalDatabase.ts:265,273,290,298) — properties['sparql'] is typed unknown but cast to string without runtime check.
- [ ] German language hardcoded (WikidataExternalDatabase.ts:220) — FILTER(LANG(?label) IN ("de", "mul")) limits label resolution to German only. 
- [ ] Doppelte Einträge in _resolveNodeTitles, falls eine Entität zusätzlich mul als Sprache für das Label hat.